### PR TITLE
[quick-fix] doc and errors

### DIFF
--- a/atlante/filestore/file/README.md
+++ b/atlante/filestore/file/README.md
@@ -3,7 +3,7 @@
 Use to copy artificates to a different location on the file system.
 
 ```toml
-[[filestores]]
+[[file_stores]]
 name = "usr/dir"
 type = "file"
 base_path="/usr/dir"

--- a/atlante/filestore/multi/README.md
+++ b/atlante/filestore/multi/README.md
@@ -7,7 +7,7 @@ for internal use only. Sheets can take multiple file stores
 , and that should be used instead. 
 
 ```toml
-[[filestores]]
+[[file_stores]]
 name = "multi"
 type = "multi"
 file_stores = [ 'usr/local/', 'null']

--- a/atlante/filestore/null/README.md
+++ b/atlante/filestore/null/README.md
@@ -3,7 +3,7 @@
 Use to throw away the file data.
 
 ```toml
-[[filestores]]
+[[file_stores]]
 name = "null"
 type = "null"
 

--- a/atlante/filestore/s3/README.md
+++ b/atlante/filestore/s3/README.md
@@ -3,7 +3,7 @@
 Use to copy artificates to s3 buckets
 
 ```toml
-[[filestores]]
+[[file_stores]]
 name = "s3"
 type = "s3"
 base_path="/"

--- a/cmd/atlante/cmd/root.go
+++ b/cmd/atlante/cmd/root.go
@@ -226,7 +226,7 @@ func LoadConfig(location string) error {
 func generatePDFForJob(ctx context.Context, jobstr string) (*atlante.GeneratedFiles, error) {
 	job, err := atlante.Base64UnmarshalJob(jobstr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%v : jobstr '%v' ", err, jobstr)
 	}
 	return a.GeneratePDFJob(ctx, *job, "")
 }
@@ -249,7 +249,7 @@ func rootCmdParseArgs(ctx context.Context) (*atlante.GeneratedFiles, error) {
 			// We need to print out what's in the job.
 			jb, err := atlante.Base64UnmarshalJob(job)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%v : jobstr '%v' ", err, job)
 			}
 			fmt.Fprintln(os.Stdout, proto.MarshalTextString(jb))
 		default:
@@ -283,6 +283,7 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 	err := LoadConfig(configFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		cmd.Usage()
 		os.Exit(1)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -292,6 +293,7 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 	if workDir != "" {
 		if err := os.Chdir(workDir); err != nil {
 			fmt.Fprintf(os.Stderr, "error changing to working dir (%v), aborting", workDir)
+			cmd.Usage()
 			os.Exit(3)
 		}
 	}
@@ -310,6 +312,7 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 		default:
 			fmt.Fprintf(os.Stderr, "error generating pdf\n\t%v\n", err)
 		}
+		cmd.Usage()
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
* Fixed doc for files stores. example pointed to using filestores,
instead of file_store

* Application errors now print usage message
* Base64 decoding error will print the string out as well