### PR TITLE
 [#17] fixed issue with s3 url gen 

### DIFF
--- a/atlante/filestore/filestore.go
+++ b/atlante/filestore/filestore.go
@@ -28,7 +28,7 @@ type timeout interface {
 // timeout errors should have a Timeout() bool on it.
 type ErrPath struct {
 	Filepath       string
-	isIntermediate bool
+	IsIntermediate bool
 	FilestoreType  string
 	Err            error
 }
@@ -38,6 +38,8 @@ func (err ErrPath) Timeout() bool {
 	t, ok := err.Err.(timeout)
 	return ok && t.Timeout()
 }
+
+func (err ErrPath) Error() string { return err.Err.Error() }
 
 // FileWriter returns a writer object
 type FileWriter interface {

--- a/atlante/filestore/s3/s3.go
+++ b/atlante/filestore/s3/s3.go
@@ -89,10 +89,12 @@ func initFunc(cfg filestore.Config) (filestore.Provider, error) {
 		intermediate:         intermediate,
 		intermediateBucket:   intermediateBucket,
 		intermediateBasePath: intermediateBasePath,
-		s3:                   s3.New(sess),
 		uploader:             s3manager.NewUploader(sess),
 		urlTimeout:           time.Duration(urlTimeout) * time.Minute,
-		genPresignedURL:      genPresigned,
+	}
+
+	if genPresigned {
+		p.s3 = s3.New(sess)
 	}
 
 	testPath := filepath.Join(p.basePath("upload_test"), "testdata")
@@ -123,7 +125,6 @@ type Provider struct {
 	intermediateBasePath string
 	uploader             *s3manager.Uploader
 
-	genPresignedURL bool
 	// used for getting signed urls
 	s3 *s3.S3
 	// time for urls that are generated if zero, then default is used.
@@ -170,7 +171,7 @@ func (p Provider) bucketPath(group, filepth string, isIntermediate bool) (bucket
 
 // PathURL will get a pre-signed URL from aws for supported files.
 func (p Provider) PathURL(group string, filepth string, isIntermediate bool) (*url.URL, error) {
-	if !p.genPresignedURL || p.s3 == nil {
+	if p.s3 == nil {
 		return nil, filestore.ErrUnsupportedOperation
 	}
 	// We don't support intermediate files for this operation
@@ -178,11 +179,12 @@ func (p Provider) PathURL(group string, filepth string, isIntermediate bool) (*u
 		return nil, filestore.ErrUnsupportedOperation
 	}
 	bucket, key := p.bucketPath(group, filepth, isIntermediate)
+	abucket, akey := aws.String(bucket), aws.String(key)
 
 	// Check to see if the key exists.
 	headObjInput := &s3.HeadObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
+		Bucket: abucket,
+		Key:    akey,
 	}
 	if _, err := p.s3.HeadObject(headObjInput); err != nil {
 		return nil, filestore.ErrPath{
@@ -194,8 +196,8 @@ func (p Provider) PathURL(group string, filepth string, isIntermediate bool) (*u
 	}
 
 	req, _ := p.s3.GetObjectRequest(&s3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
+		Bucket: abucket,
+		Key:    akey,
 	})
 	urlStr, err := req.Presign(p.urlTimeout)
 	if err != nil {


### PR DESCRIPTION
if the key was not in the s3 bucket we would still generate a presigned
url. Now we will first do a quick check and then only if the key exists
do we generate a presigned url.