### PR TITLE
[Feature] Add sheets endpoint

### DIFF
--- a/atlante/config/README.md
+++ b/atlante/config/README.md
@@ -1,0 +1,51 @@
+#Configuration of Atlante
+
+## Webserver
+
+```toml
+
+[webserver]
+
+    port = "9090"
+
+```
+
+### Properties
+
+The webserver has the following properties
+
+* `hostname` (string) : [optional] ("") the hostname
+* `port` (string) : [optional] (":8080") the port
+* `scheme` (string) : [optional] ("http") the scheme to use
+* `webserver.headers` (table) : [optional] additional headers to add to each response
+* `webserver.queue` (table) : [optional] the queue to use to send jobs to workers
+
+## Sheets
+
+```toml
+
+[[providers]]
+...
+
+[[filestores]]
+...
+
+[[sheets]]
+
+   name = "50k"
+   provider_grid = "postgistDB50k"
+   style = "files://...."
+   template = "templates/...."
+   file_stores = [ "file", "s3" ]
+
+```
+### Properties
+
+* `name` (string) : [required] the name of the sheet
+* `template` (string) : [required] the template to use 
+* `style` (string) : [required] the style to use for this sheet
+* `description` (string) : [optional] ("") the description for this sheet
+* `provider_grid` (string) : [required] the name of the grid provider
+* `file_stores` (string) : [required] the names of file stores to use
+* `dpi` (int) : [optional] (144) the DPI to use
+

--- a/atlante/config/config.go
+++ b/atlante/config/config.go
@@ -50,11 +50,11 @@ type Sheet struct {
 	Name         env.String   `toml:"name"`
 	ProviderGrid env.String   `toml:"provider_grid"`
 	Filestores   []env.String `toml:"file_stores"`
-	Scale        env.Int      `toml:"scale"`
 	DPI          env.Int      `toml:"dpi"`
 	Template     env.String   `toml:"template"`
 	Style        env.String   `toml:"style"`
 	Notifier     env.String   `toml:"notifier"`
+	Description  env.String   `toml:"description"`
 }
 
 // Validate will validate the config and make sure the is valid

--- a/atlante/grids/grid5k/README.md
+++ b/atlante/grids/grid5k/README.md
@@ -17,7 +17,7 @@ A grid provider that derives 5k grids from a configured 50k grid provider
 
 # Properties
 
-The provider support s the following properties
+The provider supports the following properties
 
 * `type` (string) : [required] should be 'grid5k'
 * `name` (string) : [required] the name of the provider (this will be normalized to the lowercase version)

--- a/atlante/server/README.md
+++ b/atlante/server/README.md
@@ -1,0 +1,73 @@
+# Webserver Endpoints
+
+The system as the following server end-points.
+
+1. `GET /sheets/` used to get the currently configured sheets.
+
+Returns
+```json
+{
+   "sheets" : []{
+        "name": string,
+        "scale" : number, // the scale in meters -- 5k => 5000; 50k => 50000
+        "description":string,
+    }
+}
+```
+
+2. `GET /sheets/${sheet_name}/info/${lat}/${lng}` used to get the grid information for the lat and long values.
+
+Returns
+```json
+{
+  "mdgid" : string,
+  "sheet_number" : null | number,
+  "pdf_url":  null | url, // if null, pdf has not be generated
+  "last_generated" :  null | date, // last time the pdf was generated
+  "last_edited" : date,  // last time the data was edited
+  "series" : string,
+  "geo_json" : geo_json // the geo_json of the bounding box.
+  "lat" :  float // the queried lat
+  "lng" : float // the queried lng
+  "sheet_name": string
+}
+```
+
+3. `GET /sheets/${sheet_name}/info/mdgid/${mdgid-sheet_number}` used to get the grid information for the mdgid
+
+Returns
+```json
+{
+  "mdgid" : string,
+  "sheet_number" : null | number,
+  "pdf_url":  null | url, // if null, pdf has not be generated
+  "last_generated" :  null | date, // last time the pdf was generated
+  "last_edited" : date,  // last time the data was edited
+  "series" : string,
+  "geo_json" : geo_json // the geo_json of the bounding box.
+  "lat" :  float // the queried lat
+  "lng" : float // the queried lng
+  "sheet_name": string
+}
+```
+
+4. `POST /sheets/${sheet_name}/mdgid` will cause the pdf generation the job to start.
+
+Expected:
+
+```json
+{
+   "mdgid" : string,
+   "sheet_number" : null | number,
+}
+```
+
+Returns:
+```json
+{
+   "mdgid" : string,
+   "sheet_number" : null | number,
+   "job_id" : number,
+   "status" : "requested" | "started" | "processing" | "compleated",
+}
+```

--- a/atlante/template_helpers.go
+++ b/atlante/template_helpers.go
@@ -6,8 +6,28 @@ import (
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
+	"text/template"
 	"time"
 )
+
+var funcMap = template.FuncMap{
+	"to_upper":    strings.ToUpper,
+	"to_lower":    strings.ToLower,
+	"format":      tplFormat,
+	"now":         time.Now,
+	"div":         tplMathDiv,
+	"add":         tplMathAdd,
+	"sub":         tplMathSub,
+	"mul":         tplMathMul,
+	"neg":         tplMathNeg,
+	"abs":         tplMathAbs,
+	"seq":         tplSeq,
+	"new_toggler": tplNewToggle,
+	"rounder_for": tplRoundTo,
+	"rounder3":    tplRound3,
+	"first":       tplFirstNonZero,
+}
 
 //tplFormat is a helper function for templates that will format the given
 // value. It uses Sprintf for most value, except time.

--- a/cmd/atlante/cmd/root.go
+++ b/cmd/atlante/cmd/root.go
@@ -160,7 +160,7 @@ func rootCmdRun(cmd *cobra.Command, args []string) error {
 		case atlante.ErrUnknownSheetName:
 			fmt.Fprintf(&strwriter, "\terror unknown sheet name `%v`\n", string(e))
 			fmt.Fprintf(&strwriter, "\tknown sheets\n")
-			for _, snm := range a.Sheets() {
+			for _, snm := range a.SheetNames() {
 				fmt.Fprintf(&strwriter, "\t\t%v\n", snm)
 			}
 		default:

--- a/cmd/atlante/config/config.go
+++ b/cmd/atlante/config/config.go
@@ -163,7 +163,7 @@ func LoadConfig(conf config.Config, dpi int, overrideDPI bool) (*atlante.Atlante
 			name,
 			prv,
 			uint(odpi),
-			uint(sheet.Scale),
+			string(sheet.Description),
 			string(sheet.Style),
 			templateURL,
 			fsprv,


### PR DESCRIPTION
Moved all endpoints to be after `sheets` and added a
`sheets` end point.

New sheets endpoint returns the configured sheets, a description, and
the scale of the sheet.

#17 