### PR TITLE
Fixed Inverted Width/Height + minor fixes

### DIFF
--- a/atlante/atlante.go
+++ b/atlante/atlante.go
@@ -333,7 +333,7 @@ func GeneratePDF(ctx context.Context, sheet *Sheet, grid *grids.Cell, filenames 
 
 	widthpts, heightpts := float64(sheet.WidthInPoints(72)), float64(sheet.HeightInPoints(72))
 	log.Infof("pdf %v,%v", widthpts, heightpts)
-	if err = svg2pdf.GeneratePDF(svgfn, pdffn, heightpts, widthpts); err != nil {
+	if err = svg2pdf.GeneratePDF(svgfn, pdffn, widthpts, heightpts); err != nil {
 		log.Warnf("error generating pdf: %v", err)
 		sheet.EmitError("generate pdf failed", err)
 		return err

--- a/atlante/atlante_test.go
+++ b/atlante/atlante_test.go
@@ -1,0 +1,129 @@
+package atlante
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/maptoolkit/svg2pdf"
+)
+
+var mediabox = regexp.MustCompile(`/MediaBox\s+\[(.+)\]`)
+
+func getWidthHeightFromPDF(t *testing.T, pdfFilename string) (width, height float64, err error) {
+	// Now we are going to hack around the pdf, and just look for the
+	file, err := os.Open(pdfFilename)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error opening pdf, expected nil got %v", err)
+	}
+	defer file.Close()
+	freader := bufio.NewReader(file)
+	idxs := mediabox.FindReaderSubmatchIndex(freader)
+	if len(idxs) != 4 {
+		t.Logf("got media box idxs: %v", idxs)
+		return 0, 0, fmt.Errorf("get media box, expect 10 idxs, got %v.", len(idxs))
+	}
+
+	// Get enough space for any of the number
+	byteBuff := make([]byte, idxs[3]-idxs[2])
+	if _, err = file.Seek(int64(idxs[2]), 0); err != nil {
+		return 0, 0, fmt.Errorf("error seeking to start , expected nil got %v", err)
+	}
+	if _, err = file.Read(byteBuff); err != nil {
+		return 0, 0, fmt.Errorf("error reading needed bytes for entries")
+	}
+	vals := bytes.Split(byteBuff, []byte{' '})
+	var fvals []float64
+	for _, bstr := range vals {
+		bstr = bytes.TrimSpace(bstr)
+		if len(bstr) == 0 {
+			continue
+		}
+		f, _ := strconv.ParseFloat(string(bstr), 64)
+		fvals = append(fvals, f)
+	}
+	if len(fvals) != 4 {
+		return 0, 0, fmt.Errorf("expected len to be 4 got: %v : %v", len(fvals), fvals)
+	}
+	width = fvals[2] - fvals[0]
+	height = fvals[3] - fvals[1]
+
+	return width, height, nil
+}
+
+func TestWidthHeightSVG2PDF(t *testing.T) {
+
+	const (
+		svgFilename = `testdata/testsvg.svg`
+	)
+
+	// got this from: https://unix.stackexchange.com/questions/39464/how-to-query-pdf-page-size-from-the-command-line
+
+	dir, err := ioutil.TempDir("", "TestWidthHeightSVG2PDF")
+	if err != nil {
+		t.Skipf("Failed to create temp dir: %v", err)
+		return
+	}
+	defer os.RemoveAll(dir)
+
+	type tcase struct {
+		Width  float64
+		Height float64
+	}
+
+	fn := func(tc tcase) (string, func(*testing.T)) {
+		tname := fmt.Sprintf("%v_%v", tc.Width, tc.Height)
+		return tname, func(t *testing.T) {
+			// let's first create a tmp pdf file name to use.
+			pdfFilename := filepath.Join(dir, tname+".pdf")
+			t.Logf("test pdf: %v", pdfFilename)
+			err := svg2pdf.GeneratePDF(svgFilename, pdfFilename, tc.Width, tc.Height)
+			if err != nil {
+				t.Errorf("error generating pdf, expected nil got %v", err)
+				return
+			}
+			width, height, err := getWidthHeightFromPDF(t, pdfFilename)
+			if err != nil {
+				t.Errorf("getting size error, expected nil, got %v", err)
+				return
+			}
+			if tc.Width != width {
+				t.Errorf("width, expected %v got %v", tc.Width, width)
+			}
+			if tc.Height != height {
+				t.Errorf("height, expected %v got %v", tc.Height, height)
+			}
+		}
+	}
+	tests := []tcase{
+		{
+			Width:  720,
+			Height: 720,
+		},
+		{
+			Width:  800,
+			Height: 600,
+		},
+		{
+			Width:  1080,
+			Height: 2048,
+		},
+		{
+			Width:  720.5,
+			Height: 830.23,
+		},
+		{
+			Width:  2337.11,
+			Height: 1765.45,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fn(tc))
+	}
+}

--- a/atlante/internal/resolution/resolution_test.go
+++ b/atlante/internal/resolution/resolution_test.go
@@ -31,26 +31,32 @@ func TestZoom(t *testing.T) {
 				"San Deigo, US": {
 					earthCircumfrence: MercatorEarthCircumference,
 					lat:               32.715736,
+					zoom:              13.281348714459781,
 				},
 				"New York, US": tcase{
 					earthCircumfrence: MercatorEarthCircumference,
 					lat:               40.785091,
+					zoom:              13.129229242614507,
 				},
 				"Umeå, Sweden": tcase{
 					earthCircumfrence: MercatorEarthCircumference,
 					lat:               63.825848,
+					zoom:              12.34973052323617,
 				},
 				"Luleå, Norrbotten, Sweden": tcase{
 					earthCircumfrence: MercatorEarthCircumference,
 					lat:               65.584816,
+					zoom:              12.255970484637578,
 				},
 				"Port Stephens, Falkland Islands": tcase{
 					earthCircumfrence: MercatorEarthCircumference,
 					lat:               -52.094273,
+					zoom:              12.827715254340175,
 				},
 				"Nakuru, Kenya": tcase{
 					earthCircumfrence: MercatorEarthCircumference,
 					lat:               -0.303099,
+					zoom:              13.53052931740004,
 				},
 			},
 		},

--- a/atlante/notifiers/http/http.go
+++ b/atlante/notifiers/http/http.go
@@ -100,7 +100,7 @@ func (e *emitter) Emit(se field.StatusEnum) error {
 			codetype = "server error"
 		}
 		bdy, _ := ioutil.ReadAll(resp.Body)
-		log.Infof("%v (%v): %v", codetype, resp.StatusCode, bdy)
+		log.Infof("%v (%v): %s", codetype, resp.StatusCode, bdy)
 	}
 	return err
 }

--- a/atlante/sheet.go
+++ b/atlante/sheet.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	// DefaultHeightMM is the default mm height if a height is not given
-	DefaultHeightMM = 28.16667
 	// DefaultWidthMM is the default mm width if a width is not given
-	DefaultWidthMM = 36.20833
+	DefaultWidthMM = 841 // A0 width
+	// DefaultHeightMM is the default mm height if a height is not given
+	DefaultHeightMM = 1189 // A0 height
 
 	// inchPerMM is the number of inches in a mm
 	inchPerMM = 1 / 25.4

--- a/cmd/atlante/cmd/server.go
+++ b/cmd/atlante/cmd/server.go
@@ -96,7 +96,7 @@ func serverCmdRunE(cmd *cobra.Command, args []string) error {
 	// Now we need to look to see if a queue has been configured
 	if conf.Webserver.Queue != nil {
 		qType, _ := conf.Webserver.Queue.String(queuer.ConfigKeyType, nil)
-		if qType != "none" || qType != "" {
+		if qType != "none" && qType != "" {
 			// Configure the queue
 			srv.Queue, err = queuer.For(qType, conf.Webserver.Queue)
 			if err != nil {
@@ -116,7 +116,7 @@ func serverCmdRunE(cmd *cobra.Command, args []string) error {
 		// cast to string
 		val := fmt.Sprintf("%v", value)
 		if val == "" {
-			fmt.Fprintln(cmd.OutOrStderr(), "warning, webserver.header (%v) has no configured value, ignoring", name)
+			fmt.Fprintf(cmd.OutOrStderr(), "warning, webserver.header (%v) has no configured value, ignoring\n", name)
 		}
 		srv.Headers[name] = val
 	}

--- a/cmd/svg2pdf/svg2pdf.go
+++ b/cmd/svg2pdf/svg2pdf.go
@@ -18,7 +18,7 @@ func init() {
 func main() {
 	flag.Parse()
 	if flag.NArg() != 2 {
-		fmt.Println("incorrect number of args (%d)", flag.NArg())
+		fmt.Printf("incorrect number of args (%d)", flag.NArg())
 		os.Exit(1)
 	}
 

--- a/svg2pdf/svg2pdf.c
+++ b/svg2pdf/svg2pdf.c
@@ -5,7 +5,7 @@
 #include <cairo-ps.h>
 
 int svg2pdf_file(const char * inFile, const char * outFile,
-		double height, double width) {
+		double width, double height) {
 	cairo_t * cr;
 	cairo_surface_t * surface;
 	RsvgHandle * handle;
@@ -53,7 +53,7 @@ int svg2pdf_file(const char * inFile, const char * outFile,
 
 	// set handle options
 
-	surface = cairo_pdf_surface_create(outFile, height, width);
+	surface = cairo_pdf_surface_create(outFile, width, height);
 	cairo_status_t status = cairo_surface_status(surface);
 	if (status != CAIRO_STATUS_SUCCESS) {
 #if DEBUG


### PR DESCRIPTION
* #66 Fixed Inverted Width/Height values. This will break people working around this bug.
Minor Fixes:
* Fixed minor things suggested by go test.
* #64 Set the default width/height to reasonable A0 size
* #55 output of error for 404 is not rendered as a string and not byte slice.
