### PR TITLE
[#74] Calculated the Last Gen from file

### DIFF
--- a/atlante/filestore/filestore.go
+++ b/atlante/filestore/filestore.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"sync"
+	"time"
 )
 
 const (
@@ -32,12 +33,34 @@ type Provider interface {
 	FileWriter(group string) (FileWriter, error)
 }
 
+// URLInfo encodes the url that can be used to get the file and the LastModified time of that url.
+type URLInfo struct {
+	URL          *url.URL
+	LastModified *time.Time
+}
+
+// String returns the string reprenstation of the URL
+func (urlinfo URLInfo) String() string {
+	if urlinfo.URL == nil {
+		return ""
+	}
+	return urlinfo.URL.String()
+}
+
+// TimeString returns the LastModified time formated according to RFC3339
+func (urlinfo URLInfo) TimeString() string {
+	if urlinfo.LastModified == nil || urlinfo.LastModified.IsZero() {
+		return ""
+	}
+	return urlinfo.LastModified.Format(time.RFC3339)
+}
+
 // Pather returns a url to the given file, the filestore supports external urls.
 // If the file does not exist return nil for the url, and a ErrPath. This can
 // be used for timeout as well. If the filestore does not support PathURLs
 // (i.e. because of configuration) then return nil for the url and a ErrUnsupportedOperation
 type Pather interface {
-	PathURL(group string, filepath string, isIntermediate bool) (*url.URL, error)
+	PathURL(group string, filepath string, isIntermediate bool) (URLInfo, error)
 }
 
 // globalWaitGroupPipe is used by pipe to keep the process running

--- a/atlante/filestore/multi/multi.go
+++ b/atlante/filestore/multi/multi.go
@@ -2,7 +2,6 @@ package multi
 
 import (
 	"io"
-	"net/url"
 
 	"github.com/gdey/errors"
 	"github.com/go-spatial/maptoolkit/atlante/filestore"
@@ -168,7 +167,7 @@ func (t FileWriter) Writer(fpath string, isIntermediate bool) (io.WriteCloser, e
 
 // PathURL will go through each of the filestore looking for the first filestore that
 // support the Pather interface and has the file and returns that url
-func (p Provider) PathURL(group string, filepath string, isIntermediate bool) (*url.URL, error) {
+func (p Provider) PathURL(group string, filepath string, isIntermediate bool) (filestore.URLInfo, error) {
 	var firstError error
 	// Search through our filestores and find the first one that supportes the
 	// pather interface and has a url for it.
@@ -188,15 +187,15 @@ func (p Provider) PathURL(group string, filepath string, isIntermediate bool) (*
 			}
 			continue
 		}
-		if furl == nil {
+		if furl.URL == nil {
 			continue
 		}
 		return furl, nil
 	}
 	if firstError != nil {
-		return nil, firstError
+		return filestore.URLInfo{}, firstError
 	}
-	return nil, filestore.ErrUnsupportedOperation
+	return filestore.URLInfo{}, filestore.ErrUnsupportedOperation
 }
 
 var _ filestore.Provider = Provider{}


### PR DESCRIPTION
The last generated time was being generated using the date of the completed task, instead of using the actual file that would be sent to the user. This changes the Pather Interface to return the LastModified Time as well as the URL for the file.

Fixes #74 