### PR TITLE
[#63] This changes the statuses table name to job_statuses

### DIFF
--- a/atlante/server/coordinator/postgresql/README.md
+++ b/atlante/server/coordinator/postgresql/README.md
@@ -88,7 +88,7 @@ WHERE id=$1
 
 ```sql
 
-INSERT INTO statuses(
+INSERT INTO job_statuses(
 	job_id,
 	status,
 	description
@@ -113,7 +113,7 @@ SELECT
     jobstatus.description,
     jobstatus.created as updated
 FROM jobs AS job
-JOIN statuses AS jobstatus ON job.id = jobstatus.job_id
+JOIN job_statuses AS jobstatus ON job.id = jobstatus.job_id
 WHERE job.id = $1
 ORDER BY jobstatus.id desc limit 1;
 ```
@@ -139,7 +139,7 @@ LEFT JOIN
 	SELECT DISTINCT ON (job_id)
 	*
 	FROM
-	   statuses
+	   job_statuses
 	ORDER BY
 	   job_id, id DESC
 ) AS jobstatus ON jobstatus.job_id = job.id
@@ -176,7 +176,7 @@ LEFT JOIN
 	SELECT DISTINCT ON (job_id)
 	*
 	FROM 
-	   statuses
+	   job_statuses
 	ORDER BY
 	   job_id, id DESC
 ) AS jobstatus ON jobstatus.job_id = job.id

--- a/atlante/server/coordinator/postgresql/docs/jobs_00.sql
+++ b/atlante/server/coordinator/postgresql/docs/jobs_00.sql
@@ -22,7 +22,7 @@ CREATE INDEX ON jobs (queue_id);
 CREATE INDEX bounds_polygon_idx ON jobs USING GIST (bounds);
 
 
-CREATE TABLE statuses (
+CREATE TABLE job_statuses (
     id SERIAL PRIMARY KEY,
     job_id INTEGER NOT NULL,
     status TEXT NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE statuses (
 );
 
 
-CREATE INDEX ON statuses (job_id);
+CREATE INDEX ON job_statuses (job_id);
 
 -- Find job by job id
 SELECT 
@@ -44,6 +44,6 @@ SELECT
     jobstatus.description,
     jobstatus.created as updated
 FROM jobs AS job
-JOIN statuses AS jobstatus ON job.id = jobstatus.job_id
+JOIN job_statuses AS jobstatus ON job.id = jobstatus.job_id
 WHERE job.id = $1
 ORDER BY jobstatus.id desc limit 1;

--- a/atlante/server/coordinator/postgresql/docs/jobs_01.sql
+++ b/atlante/server/coordinator/postgresql/docs/jobs_01.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS statuses
+RENAME TO job_statuses

--- a/atlante/server/coordinator/postgresql/postgresql.go
+++ b/atlante/server/coordinator/postgresql/postgresql.go
@@ -313,7 +313,7 @@ SET job_data=$2
 WHERE id=$1
 	`
 	const insertStatusQuery = `
-INSERT INTO statuses(
+INSERT INTO job_statuses(
 	job_id,
 	status,
 	description
@@ -391,7 +391,7 @@ LEFT JOIN
 	SELECT DISTINCT ON (job_id)
 	*
 	FROM
-	   statuses
+	   job_statuses
 	ORDER BY
 	   job_id, id DESC
 ) AS jobstatus ON jobstatus.job_id = job.id
@@ -470,7 +470,7 @@ SELECT
     jobstatus.description,
     jobstatus.created as updated
 FROM jobs AS job
-JOIN statuses AS jobstatus ON job.id = jobstatus.job_id
+JOIN job_statuses AS jobstatus ON job.id = jobstatus.job_id
 WHERE job.id = $1
 ORDER BY jobstatus.id desc limit 1;
 	`
@@ -574,7 +574,7 @@ LEFT JOIN
 	SELECT DISTINCT ON (job_id)
 	*
 	FROM 
-	   statuses
+	   job_statuses
 	ORDER BY
 	   job_id, id DESC
 ) AS jobstatus ON jobstatus.job_id = job.id


### PR DESCRIPTION
This fix will break people's instances. If they are using the default setup, the system will not be looking for job_statues table instead of statues. Please alter your db tables as necessary.