### PR TITLE
[89] return 404 for request with missing grids.

### DIFF
--- a/atlante/grids/cell.go
+++ b/atlante/grids/cell.go
@@ -43,7 +43,9 @@ const (
 )
 
 // Provider returns a grid object that can be used to generate
-// a Map Grid
+// a Map Grid, if the grid object is not found or does not exist
+// the CellFor* methods should return a nil cell, and ErrNotFound
+// error
 type Provider interface {
 	CellForLatLng(lat, lng float64, srid uint) (*Cell, error)
 	CellForMDGID(mgdID *MDGID) (*Cell, error)

--- a/atlante/grids/errors.go
+++ b/atlante/grids/errors.go
@@ -1,0 +1,28 @@
+package grids
+
+import (
+	"github.com/gdey/errors"
+)
+
+const (
+	// ErrNotFound is returned when an requested object does not exist in the
+	// grid provider
+	ErrNotFound = errors.String("grid not found")
+
+	// ErrNoProvidersRegistered is returned when providers have not been registered with the system
+	ErrNoProvidersRegistered = errors.String("no providers registered")
+)
+
+// ErrProviderTypeExists is returned when the Provider type was already registered.
+type ErrProviderTypeExists string
+
+func (err ErrProviderTypeExists) Error() string {
+	return "provider (" + string(err) + ") already exists"
+}
+
+// ErrProviderNotRegistered is returned when the requested provider has not registered
+type ErrProviderNotRegistered string
+
+func (err ErrProviderNotRegistered) Error() string {
+	return "provider (" + string(err) + ") not registered"
+}

--- a/atlante/grids/postgresql/postgresql.go
+++ b/atlante/grids/postgresql/postgresql.go
@@ -409,6 +409,9 @@ func (p *Provider) cellFromRow(row *pgx.Row) (*grids.Cell, error) {
 		&editedAt,
 	)
 	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, grids.ErrNotFound
+		}
 		return nil, err
 	}
 

--- a/atlante/grids/register.go
+++ b/atlante/grids/register.go
@@ -1,30 +1,12 @@
 package grids
 
 import (
-	"errors"
 	"sort"
 	"sync"
 
 	"github.com/go-spatial/tegola/dict"
 	"github.com/prometheus/common/log"
 )
-
-// ErrProviderTypeExists is returned when the Provider type was already registered.
-type ErrProviderTypeExists string
-
-func (err ErrProviderTypeExists) Error() string {
-	return "provider (" + string(err) + ") already exists"
-}
-
-// ErrNoProvidersRegistered is returned when providers have not been registered with the system
-var ErrNoProvidersRegistered = errors.New("no providers registered")
-
-// ErrProviderNotRegistered is returned when the requested provider has not registered
-type ErrProviderNotRegistered string
-
-func (err ErrProviderNotRegistered) Error() string {
-	return "provider (" + string(err) + ") not registered"
-}
 
 // ProviderConfig implements the ProviderConfig interface
 type ProviderConfig interface {

--- a/atlante/server/server.go
+++ b/atlante/server/server.go
@@ -327,6 +327,10 @@ func (s *Server) GridInfoHandler(w http.ResponseWriter, request *http.Request, u
 		mdgid = grids.NewMDGID(mdgidStr)
 		cell, err = sheet.CellForMDGID(mdgid)
 		if err != nil {
+			if err == grids.ErrNotFound {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
 			badRequest(w, "error getting grid(%v):%v", mdgidStr, err)
 			return
 		}
@@ -358,6 +362,10 @@ func (s *Server) GridInfoHandler(w http.ResponseWriter, request *http.Request, u
 		// the url?
 		cell, err = sheet.CellForLatLng(lat, lng, srid)
 		if err != nil {
+			if err == grids.ErrNotFound {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
 			badRequest(w, "error getting grid(%v,%v,srid: %v):%v", lat, lng, srid, err)
 			return
 		}


### PR DESCRIPTION
Instead of returning a BadRequest and logging out no rows found, we will instead return a 404, and log nothing for missing grids.

fixes #89 