### PR TITLE
[#86] Allowed queue id to be null

### DIFF
--- a/atlante/server/server.go
+++ b/atlante/server/server.go
@@ -490,6 +490,12 @@ func (s *Server) QueueHandler(w http.ResponseWriter, request *http.Request, urlP
 
 	qjobid, err := s.Queue.Enqueue(jb.JobID, &qjob)
 	if err != nil {
+		s.Coordinator.UpdateField(jb,
+			field.Status{field.Failed{
+				Description: "Failed to enqueue job",
+				Error:       err,
+			}},
+		)
 		badRequest(w, "failed to queue job: %v", err)
 		return
 	}


### PR DESCRIPTION
Get were breaking if queue_id was null. This is possible if the system errored trying to enqueue something and the queue system returned and error.

* We now do not break on job that failed to enqueue.
* Added a proper failed status if the job fails to enqueue
* log jobs that have bad status or queue_id's

Fixes #86 