### PR TITLE
Issue 103: Add support for remote svgs

### DIFF
--- a/atlante/README.md
+++ b/atlante/README.md
@@ -1,0 +1,66 @@
+# Supported Template functions
+
+* to_upper : upper case the given string
+
+`{{ to_upper "hello world" }}`
+returns
+HELLO WORLD
+
+
+* to_lower : lower case the given string
+
+`{{ to_lower "HELLO WORLD" }}`
+returns
+hello world
+
+* format : format the given value
+
+`{{ format "%03v" 5 }}`
+returns
+005
+
+for Date values use a date format
+
+
+* now : returns the current time
+
+* div : div the first value from the second value
+
+`{{ div 4 2 }}`
+returns
+2
+
+* mul : multiple the first value from the second
+
+* add : add the first value from the second
+
+* sub : sub the first value from the second
+
+* neg : negate the value
+
+* abs : return the absolute value of the value
+
+* seq : generate a sequence of number from the first to the second in steps of the third
+
+* new_toggler : create a toggler that will flip between a given set of values
+
+* rounder3 : round the value to 3 places
+
+* first : return the first non zero value of the given set of values
+
+* DrawBars : draw utm grid
+
+** asIntSlice : return the set of numbers as a slice of ints (used for DrawBars)
+ 
+** pixel_bounds :  return the set of number as a pixelBounds (used for DrawBars)
+
+* remote : retrieve the given remote svg and return it's workdir location
+
+```svg
+
+{{$partial := remote "http://view-source:https://upload.wikimedia.org/wikipedia/commons/1/1a/SVG_example_markup_grid.svg}}
+<rect fill="url({{$partial}}#grid)" stroke-width="2" stroke="#000" x="0" y="0" width="250" height="250"/>
+<text>{{$partial}}</text>
+```
+
+

--- a/atlante/README.md
+++ b/atlante/README.md
@@ -1,3 +1,14 @@
+# Environmental variables
+
+To turn on experimental cache support set the `ATLANTE_USED_CACHED_IMAGES` to a true value.
+
+```
+ATLANTE_USED_CACHED_IMAGES=1
+```
+
+Generated and remote assets will only be retrieved/generated if they don't already exist in the work directory.
+
+
 # Supported Template functions
 
 * to_upper : upper case the given string

--- a/atlante/atlante.go
+++ b/atlante/atlante.go
@@ -281,6 +281,12 @@ func GeneratePDF(ctx context.Context, sheet *Sheet, grid *grids.Cell, filenames 
 		return ErrNilGrid
 	}
 
+	useCached := false
+	if val, ok := os.LookupEnv("ATLANTE_USED_CACHED_IMAGES"); ok {
+		useCached, _ = strconv.ParseBool(val)
+		log.Infof("ATLANTE_USED_CACHED_IMAGES=%t", useCached)
+	}
+
 	sheet.Emit(field.Started{})
 
 	// TODO(gdey): use MdgID once we move to partial templates system
@@ -304,6 +310,9 @@ func GeneratePDF(ctx context.Context, sheet *Sheet, grid *grids.Cell, filenames 
 			multiWriter.Writers = append(multiWriter.Writers, shWriter)
 		}
 	}
+
+	sheet.FuncFilestoreWriter = multiWriter
+	sheet.UseCached = useCached
 
 	log.Infoln("filenames: ", filenames.IMG, filenames.SVG, filenames.PDF)
 
@@ -353,12 +362,6 @@ func GeneratePDF(ctx context.Context, sheet *Sheet, grid *grids.Cell, filenames 
 	}
 	if ctx.Err() != nil {
 		return ctx.Err()
-	}
-
-	useCached := false
-	if val, ok := os.LookupEnv("ATLANTE_USED_CACHED_IMAGES"); ok {
-		useCached, _ = strconv.ParseBool(val)
-		log.Infof("ATLANTE_USED_CACHED_IMAGES=%t", useCached)
 	}
 
 	img := ImgStruct{

--- a/atlante/filestore/multi/multi.go
+++ b/atlante/filestore/multi/multi.go
@@ -85,7 +85,7 @@ func init() {
 // that overall write operation stops and returns the error; it does not continue
 // down the list.
 //
-// This is heavily influnced by io.MultiWriter
+// This is heavily influenced by io.MultiWriter
 type Writer struct {
 	writers []io.WriteCloser
 }

--- a/atlante/template/remote/remote.go
+++ b/atlante/template/remote/remote.go
@@ -36,9 +36,8 @@ func Remote(location string, fswriter filestore.FileWriter, useCached bool) (str
 	if err != nil {
 		return "", err
 	}
-	hostname := strings.ToLower(loc.Hostname())
-	normalizeURL := fmt.Sprintf("%v://%v/%v?%v#%v", loc.Scheme, hostname, loc.RawPath, loc.RawQuery, loc.Fragment)
-	shaBytes := sha1.Sum([]byte(normalizeURL))
+	loc.Host = strings.ToLower(loc.Hostname())
+	shaBytes := sha1.Sum([]byte(loc.String()))
 	shaFilename := fmt.Sprintf("%x", shaBytes)
 	svgBytes, err := urlutil.ReadAll(loc)
 	if err != nil {

--- a/atlante/template/remote/remote.go
+++ b/atlante/template/remote/remote.go
@@ -1,0 +1,77 @@
+package remote
+
+import (
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-spatial/maptoolkit/atlante/filestore"
+	"github.com/go-spatial/maptoolkit/atlante/internal/urlutil"
+)
+
+var RemoteDir = "remoteasset"
+
+type remoteMeta struct {
+	Filename string    `json:"filename"`
+	ETag     string    `json:"etag"`
+	URL      string    `json:"url"`
+	Date     time.Time `json:"timestamp"`
+}
+
+func attemptWrite(w filestore.FileWriter, name string, data []byte) (n int, err error) {
+	writer, err := w.Writer(name, true)
+	if err != nil {
+		return 0, err
+	}
+	return writer.Write(data)
+}
+
+func Remote(location string, fswriter filestore.FileWriter, useCached bool) (string, error) {
+	loc, err := url.Parse(location)
+	if err != nil {
+		return "", err
+	}
+	hostname := strings.ToLower(loc.Hostname())
+	normalizeURL := fmt.Sprintf("%v://%v/%v?%v#%v", loc.Scheme, hostname, loc.RawPath, loc.RawQuery, loc.Fragment)
+	shaBytes := sha1.Sum([]byte(normalizeURL))
+	shaFilename := fmt.Sprintf("%x", shaBytes)
+	svgBytes, err := urlutil.ReadAll(loc)
+	if err != nil {
+		return "", err
+	}
+	svgFilename := filepath.Join(RemoteDir, shaFilename+".svg")
+
+	if useCached {
+		exister, ok := fswriter.(filestore.Exister)
+		if ok {
+			if exister.Exists(svgFilename) {
+				return svgFilename, nil
+			}
+		}
+	}
+
+	metaFilename := filepath.Join(RemoteDir, shaFilename+".json")
+	meta := remoteMeta{
+		Filename: svgFilename,
+		URL:      location,
+		Date:     time.Now(),
+	}
+	// if there is an err  the meta data let's not worry about it.
+	if metaBytes, err := json.Marshal(meta); err == nil {
+		if _, err = attemptWrite(fswriter, metaFilename, metaBytes); err != nil {
+			return "", err
+		}
+	} else {
+		log.Printf("issue marshaling meta data for %v: %v", location, err)
+	}
+
+	if _, err = attemptWrite(fswriter, svgFilename, svgBytes); err != nil {
+		return "", err
+	}
+	return svgFilename, nil
+}

--- a/atlante/template_helpers.go
+++ b/atlante/template_helpers.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/go-spatial/geom"
 	"github.com/go-spatial/geom/planar/coord"
+	"github.com/go-spatial/maptoolkit/atlante/server/coordinator/field"
+	"github.com/go-spatial/maptoolkit/atlante/template/remote"
 	"github.com/go-spatial/maptoolkit/atlante/template/trellis"
 )
 
@@ -36,6 +38,24 @@ var funcMap = template.FuncMap{
 	"DrawBars":     TplDrawBars,
 	"asIntSlice":   IntSlice,
 	"pixel_bounds": PixelBounds,
+}
+
+// AddTemplateFunc will add the filestore based commands. It will panic if the command is already defined.
+func (sheet *Sheet) AddTemplateFuncs(funcMap template.FuncMap) template.FuncMap {
+	add := func(name string, fn interface{}) {
+		if _, ok := funcMap[name]; ok {
+			panic(fmt.Sprintf("func %v already defined", name))
+		}
+		funcMap[name] = fn
+	}
+	add("remote", sheet.templateFuncRemote)
+
+	return funcMap
+}
+
+func (sheet *Sheet) templateFuncRemote(loc string) (string, error) {
+	sheet.Emit(field.Processing{Description: fmt.Sprintf("remote file: %v", loc)})
+	return remote.Remote(loc, sheet.FuncFilestoreWriter, sheet.UseCached)
 }
 
 //tplFormat is a helper function for templates that will format the given

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y update
 RUN yum group install -y "Development Tools"
 
 # Install Go
-RUN curl -SL https://dl.google.com/go/go1.12.4.linux-amd64.tar.gz | tar -xzC /usr/local && mkdir -p /go/bin
+RUN curl -SL https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz | tar -xzC /usr/local && mkdir -p /go/bin
 
 ENV GO111MODULE=on
 ENV GOROOT=/usr/local/go

--- a/docker/Dockerfile-development
+++ b/docker/Dockerfile-development
@@ -14,8 +14,8 @@ RUN yum -y install  https://centos7.iuscommunity.org/ius-release.rpm
 RUN yum -y install  git2u-all
 
 
-# Install go 1.11
-RUN curl -SL https://dl.google.com/go/go1.12.4.linux-amd64.tar.gz | tar -xzC /usr/local && mkdir -p /go/bin
+# Install go 1.13
+RUN curl -SL https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz | tar -xzC /usr/local && mkdir -p /go/bin
 
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/go


### PR DESCRIPTION
fixes #103 

This adds support for remote svgs.

```
{{$partial := remote "http://view-source:https://upload.wikimedia.org/wikipedia/commons/1/1a/SVG_example_markup_grid.svg}}
<rect fill="url({{$partial}}#grid)" stroke-width="2" stroke="#000" x="0" y="0" width="250" height="250"/>
```